### PR TITLE
Minor issues

### DIFF
--- a/raid_arcconf_zabbix_lld.py
+++ b/raid_arcconf_zabbix_lld.py
@@ -97,10 +97,14 @@ def col_value(data, key, index=0):
 
     for line in data.splitlines():
         columns = line.split(' : ')
+        col_num = len(columns)
         col_key = columns[0].strip()
         if col_key == key:
             if col_index == index:
-                return columns[1].strip()
+                if col_num == 2:
+                    return columns[1].strip()
+                elif col_num == 3:
+                    return columns[1].strip() + ' ' + columns[2].strip()
             col_index += 1
                 
     # Nothing found?

--- a/raid_arcconf_zabbix_lld.xml
+++ b/raid_arcconf_zabbix_lld.xml
@@ -742,12 +742,12 @@ https://github.com/YSmetana/raid_arcconf_zabbix_lld</description>
                             <logtimefmt/>
                         </item_prototype>
                         <item_prototype>
-                            <name>Logical device {#OBJ_ID} {#OBJ_ALIAS} write-cache setting</name>
+                            <name>Logical device {#OBJ_ID} {#OBJ_ALIAS} write-cache status</name>
                             <type>0</type>
                             <snmp_community/>
                             <multiplier>0</multiplier>
                             <snmp_oid/>
-                            <key>raid.arcconf[ld,{#OBJ_ID},Write-cache setting]</key>
+                            <key>raid.arcconf[ld,{#OBJ_ID},Write-cache status]</key>
                             <delay>3600</delay>
                             <history>30</history>
                             <trends>365</trends>
@@ -805,7 +805,7 @@ https://github.com/YSmetana/raid_arcconf_zabbix_lld</description>
                             <type>0</type>
                         </trigger_prototype>
                         <trigger_prototype>
-                            <expression>{Service_Adaptec_Raid:raid.arcconf[ld,{#OBJ_ID},Write-cache setting].str(On)}=0</expression>
+                            <expression>{Service_Adaptec_Raid:raid.arcconf[ld,{#OBJ_ID},Write-cache status].str(On)}=0</expression>
                             <name>LD {#OBJ_ID} {#OBJ_ALIAS} write-cache disabled on {HOST.NAME}</name>
                             <url/>
                             <status>0</status>


### PR DESCRIPTION
- During rebuild process, "_Status of Logical Device_" key in "_Logical device information_" section value contains extra colon (:) e.g. "_Degraded, Rebuilding ( Rebuild : 38 % )_" or "_Suboptimal, Rebuilding ( Rebuild : 1 % )_"
- "_Write-cache setting_" key in "_Logical device information_" has value "(Enabled|Disabled)", instead, stick to "_Write-cache status_" which has value "(On|Off)"

I'am using fw: 7.11-0 (33173), model: Adaptec ASR8405